### PR TITLE
[codex] Fix Chart component export

### DIFF
--- a/.changeset/chart-component-export.md
+++ b/.changeset/chart-component-export.md
@@ -1,0 +1,5 @@
+---
+'@ebuckleyk/frost-ui': patch
+---
+
+Fix the Chart component folder import export.

--- a/package.json
+++ b/package.json
@@ -16,6 +16,10 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     },
+    "./components/Chart": {
+      "types": "./dist/types/components/Chart/index.d.ts",
+      "import": "./dist/components/Chart/Chart.js"
+    },
     "./components/*": {
       "types": "./dist/types/components/*.d.ts",
       "import": "./dist/components/*.js"


### PR DESCRIPTION
## Summary

Adds an explicit package export for `@ebuckleyk/frost-ui/components/Chart` so consumers using the documented folder import resolve to the emitted Chart module.

## Details

The existing wildcard export maps `./components/*` to `./dist/components/*.js`, but the build emits Chart at `dist/components/Chart/Chart.js`. The exact `./components/Chart` export now points to the emitted JavaScript and declaration barrel.

## Release

Adds a patch Changeset for `@ebuckleyk/frost-ui`.

## Validation

- `npm.cmd run build`
- `npm.cmd run lint`
- `node --input-type=module -e "console.log(import.meta.resolve('@ebuckleyk/frost-ui/components/Chart'))"`
