### PR TITLE
Fix package exports and theme persistence

### DIFF
--- a/.changeset/cool-frost-builds.md
+++ b/.changeset/cool-frost-builds.md
@@ -1,0 +1,5 @@
+---
+'@ebuckleyk/frost-ui': minor
+---
+
+Fix component subpath exports and ESM package output, restore persisted theme behavior, and improve build and calendar test reliability.

--- a/components.json
+++ b/components.json
@@ -5,7 +5,7 @@
   "tsx": true,
   "tailwind": {
     "config": "tailwind.config.js",
-    "css": "src/styles/globals.css",
+    "css": "src/styles/frostui.css",
     "baseColor": "slate",
     "cssVariables": true
   },

--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "@ebuckleyk/frost-ui",
   "version": "1.18.0",
   "description": "React component library for ebuckleyk applications utilizing glassmorphism",
-  "main": "dist/index.js",
-  "module": "dist/index.js",
+  "main": "dist/index.mjs",
+  "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "files": [
     "dist"
@@ -14,26 +14,27 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "import": "./dist/index.mjs"
     },
     "./components/Chart": {
       "types": "./dist/types/components/Chart/index.d.ts",
-      "import": "./dist/components/Chart/Chart.js"
+      "import": "./dist/components/Chart/Chart.mjs"
     },
     "./components/*": {
-      "types": "./dist/types/components/*.d.ts",
-      "import": "./dist/components/*.js"
+      "types": "./dist/types/components/*/index.d.ts",
+      "import": "./dist/components/*/*.mjs"
     },
     "./hooks/*": {
       "types": "./dist/types/hooks/*.d.ts",
-      "import": "./dist/hooks/*.js"
+      "import": "./dist/hooks/*.mjs"
     },
     "./styles.css": "./dist/styles/frostui.css",
     "./tailwind.css": "./dist/styles/tailwind.css",
     "./utilities.css": "./dist/styles/utilities.css",
-    "./presets/theme": "./dist/styles/theme-preset.js"
+    "./presets/theme": "./dist/styles/theme-preset.mjs"
   },
   "scripts": {
+    "prebuild": "node -e \"require('node:fs').rmSync('dist', { recursive: true, force: true })\"",
     "build": "rollup -c --bundleConfigAsCjs",
     "format": "prettier --write \"src/**/*.{js,ts,tsx,mjs,cjs,json}\"",
     "storybook": "storybook dev -p 6006",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -12,12 +12,15 @@ import { visualizer } from 'rollup-plugin-visualizer';
 
 import packageJson from './package.json';
 
+const peerDependencies = Object.keys(packageJson.peerDependencies || {});
+const isPeerDependency = (id) => peerDependencies.some((dependency) => id === dependency || id.startsWith(`${dependency}/`));
+
 /**
  * @type {import('rollup').RollupOptions}
  */
 const config = {
   input: ['src/index.ts', 'src/styles/index.ts', 'src/styles/theme-preset.js'],
-  external: Object.keys(packageJson.peerDependencies || {}),
+  external: isPeerDependency,
   output: [
     {
       dir: 'dist',
@@ -27,9 +30,9 @@ const config = {
       preserveModulesRoot: 'src',
       entryFileNames: (chunkInfo) => {
         if (chunkInfo.name.includes('node_modules')) {
-          return chunkInfo.name.replace('node_modules', 'external') + '.js';
+          return chunkInfo.name.replace('node_modules', 'external') + '.mjs';
         }
-        return '[name].js';
+        return '[name].mjs';
       },
     },
   ],
@@ -84,6 +87,6 @@ const typesConfig = {
   output: [{ file: 'dist/index.d.ts', format: 'esm' }],
   plugins: [dts()],
   // https://stackoverflow.com/questions/71848226/creating-react-library-with-rollup-js-i-get-error-null-reading-usestate/7260405
-  external: [/\.(css|less|scss)$/, ...(Object.keys(packageJson.peerDependencies) || {})],
+  external: (id) => /\.(css|less|scss)$/.test(id) || isPeerDependency(id),
 };
 export default [config, typesConfig];

--- a/src/components/ButtonGroup/ButtonGroup.tsx
+++ b/src/components/ButtonGroup/ButtonGroup.tsx
@@ -3,7 +3,8 @@ import { Slot } from '@radix-ui/react-slot';
 import { cva, type VariantProps } from 'class-variance-authority';
 
 import { cn } from '@/lib/utils';
-import { Separator } from '@/components/Separator';
+
+import { Separator } from '../Separator';
 
 const buttonGroupVariants = cva(
   `

--- a/src/components/Calendar/Calendar.test.tsx
+++ b/src/components/Calendar/Calendar.test.tsx
@@ -9,6 +9,7 @@ const Component = () => {
     <Calendar
       mode="single"
       startMonth={new Date(2024, 4)}
+      defaultMonth={new Date(2026, 5, 6)}
       selected={date}
       className="
       rounded-md border shadow-sm
@@ -18,6 +19,15 @@ const Component = () => {
 };
 
 describe('Calendar', () => {
+  beforeAll(() => {
+    vi.useFakeTimers({ toFake: ['Date'] });
+    vi.setSystemTime(new Date(2026, 5, 6, 12));
+  });
+
+  afterAll(() => {
+    vi.useRealTimers();
+  });
+
   it('should render Calendar component to match snapshot', () => {
     const result = render(<Component />);
     expect(result).toMatchSnapshot();

--- a/src/components/Calendar/Calendar.tsx
+++ b/src/components/Calendar/Calendar.tsx
@@ -180,8 +180,8 @@ function Calendar({
         ...classNames,
       }}
       components={{
-        Root: ({ className, ...props }) => {
-          return <div data-slot="calendar" className={cn(className)} {...props} />;
+        Root: ({ className, rootRef, ...props }) => {
+          return <div ref={rootRef} data-slot="calendar" className={cn(className)} {...props} />;
         },
         Chevron: ({ className, orientation, ...props }) => {
           if (orientation === 'left') {

--- a/src/components/EventCalendar/EventCalendar.test.tsx
+++ b/src/components/EventCalendar/EventCalendar.test.tsx
@@ -133,10 +133,19 @@ const events: EventCalendarEvent[] = [
 
 const Component = () => {
   const ref = React.useRef<InstanceType<typeof FullCalendar>>(null);
-  return <EventCalendar ref={ref} events={events} />;
+  return <EventCalendar ref={ref} events={events} calendarProps={{ initialDate: '2026-06-06' }} />;
 };
 
 describe('EventCalendar', () => {
+  beforeAll(() => {
+    vi.useFakeTimers({ toFake: ['Date'] });
+    vi.setSystemTime(new Date(2026, 5, 6, 12));
+  });
+
+  afterAll(() => {
+    vi.useRealTimers();
+  });
+
   it('should render EventCalendar component to match snapshot', () => {
     const result = render(<Component />);
     expect(result).toMatchSnapshot();

--- a/src/components/ScrollArea/ScrollArea.test.tsx
+++ b/src/components/ScrollArea/ScrollArea.test.tsx
@@ -12,12 +12,10 @@ function Component() {
       <div className="p-4">
         <h4 className="mb-4 text-sm leading-none font-medium">Tags</h4>
         {tags.map((tag) => (
-          <>
-            <div key={tag} className="text-sm">
-              {tag}
-            </div>
+          <React.Fragment key={tag}>
+            <div className="text-sm">{tag}</div>
             <Separator className="my-2" />
-          </>
+          </React.Fragment>
         ))}
       </div>
     </ScrollArea>

--- a/src/components/ThemeProvider/ThemeProvider.test.tsx
+++ b/src/components/ThemeProvider/ThemeProvider.test.tsx
@@ -1,0 +1,54 @@
+import * as React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { ThemeProvider, useTheme } from './ThemeProvider';
+
+const storageKey = 'frost-ui-theme-test';
+
+function ThemeConsumer() {
+  const { theme, setTheme } = useTheme();
+
+  return (
+    <button type="button" onClick={() => setTheme('light')}>
+      {theme}
+    </button>
+  );
+}
+
+describe('ThemeProvider', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.documentElement.classList.remove('dark', 'light');
+  });
+
+  it('restores and applies a stored theme', () => {
+    localStorage.setItem(storageKey, 'dark');
+
+    render(
+      <ThemeProvider storageKey={storageKey}>
+        <ThemeConsumer />
+      </ThemeProvider>,
+    );
+
+    expect(screen.getByRole('button')).toHaveTextContent('dark');
+    expect(document.documentElement).toHaveClass('dark');
+  });
+
+  it('updates state, storage, and the document class', () => {
+    render(
+      <ThemeProvider storageKey={storageKey} theme="dark">
+        <ThemeConsumer />
+      </ThemeProvider>,
+    );
+
+    fireEvent.click(screen.getByRole('button'));
+
+    expect(screen.getByRole('button')).toHaveTextContent('light');
+    expect(localStorage.getItem(storageKey)).toBe('light');
+    expect(document.documentElement).toHaveClass('light');
+  });
+
+  it('throws when useTheme is used outside ThemeProvider', () => {
+    expect(() => render(<ThemeConsumer />)).toThrow('useTheme must be used within a ThemeProvider');
+  });
+});

--- a/src/components/ThemeProvider/ThemeProvider.tsx
+++ b/src/components/ThemeProvider/ThemeProvider.tsx
@@ -15,15 +15,10 @@ type ThemeProviderState = {
   setTheme: (theme: Theme) => void;
 };
 
-const initialState: ThemeProviderState = {
-  theme: 'system',
-  setTheme: () => null,
-};
-
 const MEDIA = '(prefers-color-scheme: dark)';
 const isServer = typeof window === 'undefined';
 
-const ThemeProviderContext = createContext<ThemeProviderState>(initialState);
+const ThemeProviderContext = createContext<ThemeProviderState | undefined>(undefined);
 
 export function ThemeProvider({
   children,
@@ -31,7 +26,7 @@ export function ThemeProvider({
   storageKey = 'ebuckleyk/frost-ui-theme',
   ...props
 }: ThemeProviderProps) {
-  const [themeState, setThemeState] = useState<Theme>(() => theme || getTheme(storageKey, theme));
+  const [themeState, setThemeState] = useState<Theme>(() => getTheme(storageKey, theme));
 
   const applyTheme = useCallback((t: Theme) => {
     const root = window.document.documentElement;
@@ -60,8 +55,8 @@ export function ThemeProvider({
 
   const setTheme = useCallback(
     (t: Theme) => {
+      setThemeState(t);
       try {
-        setThemeState(t);
         localStorage.setItem(storageKey, t);
       } catch {
         // unsupported
@@ -75,13 +70,12 @@ export function ThemeProvider({
     const handleStorage = (e: StorageEvent) => {
       if (e.key !== storageKey) return;
 
-      const t = (e.newValue || themeState) as Theme;
-      setTheme(t);
+      if (isTheme(e.newValue)) setThemeState(e.newValue);
     };
 
     window.addEventListener('storage', handleStorage);
     return () => window.removeEventListener('storage', handleStorage);
-  }, [setTheme, storageKey, themeState]);
+  }, [storageKey]);
 
   // always listen to System preference
   useEffect(() => {
@@ -94,19 +88,17 @@ export function ThemeProvider({
     return () => media.removeListener(handleMediaQuery);
   }, [handleMediaQuery]);
 
-  // whenever theme changes, apply it
-  useEffect(() => {
-    setTheme(theme || 'system');
-  }, [applyTheme, setTheme, theme]);
-
   useEffect(() => {
     applyTheme(themeState);
   }, [applyTheme, themeState]);
 
-  const providerValue: ThemeProviderState = {
-    theme: themeState,
-    setTheme,
-  };
+  const providerValue = React.useMemo<ThemeProviderState>(
+    () => ({
+      theme: themeState,
+      setTheme,
+    }),
+    [setTheme, themeState],
+  );
 
   return (
     <ThemeProviderContext.Provider {...props} value={providerValue}>
@@ -132,11 +124,12 @@ const getSystemTheme = (e?: MediaQueryList | MediaQueryListEvent): Theme => {
 
 const getTheme = (key: string, fallback: Theme): Theme => {
   if (isServer) return fallback;
-  let theme: Theme = fallback;
   try {
-    theme = (localStorage.getItem(key) as Theme) || undefined;
+    const storedTheme = localStorage.getItem(key);
+    return isTheme(storedTheme) ? storedTheme : fallback;
   } catch {
-    /* empty */
+    return fallback;
   }
-  return theme || fallback;
 };
+
+const isTheme = (value: string | null): value is Theme => value === 'dark' || value === 'light' || value === 'system';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -32,6 +32,7 @@ export * from './HoverCard';
 export * from './Input';
 export * from './InputGroup';
 export * from './InputOTP';
+export * from './Icons';
 export * from './Item';
 export * from './Kbd';
 export * from './Label';


### PR DESCRIPTION
## What changed

- Correct component and hook subpath exports and publish ESM output as `.mjs`.
- Clean `dist` before builds and externalize peer dependency subpaths during declaration bundling.
- Restore persisted theme initialization, validate stored values, and enforce provider usage.
- Export `Icons`, fix Calendar root ref forwarding, and stabilize date-dependent snapshots.
- Correct the shadcn stylesheet path and add a minor changeset.

## Why

The documented direct component imports resolved to paths that were not emitted by the build, persisted themes were overwritten during provider initialization, and calendar snapshots depended on the current date. Builds could also retain stale artifacts between runs.

## Impact

Consumers can use the documented tree-shakable imports, Node loads the ESM output without module-format warnings, persisted themes survive remounts, and release/test output is deterministic.

## Validation

- `npm run lint`
- `npx tsc --noEmit`
- `npm run build`
- Full Vitest suite: 66 files and 91 tests passed.
- Verified root, Button, Chart, Icons, hook, and theme-preset package imports.
